### PR TITLE
Add kiss_chat social button to homepage nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist
 /docs*
 /.vscode
+/.claude/launch.json
 *.log
 blog/*.html
 public/icons.svg

--- a/index.html
+++ b/index.html
@@ -81,6 +81,59 @@
 							<use href="/icons.svg#bi-github"></use></svg
 					></a>
 					<a
+						href="https://crates.io/crates/kiss_chat"
+						class="icon"
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="kiss_chat on crates.io (opens in new tab)"
+						><svg
+							class="bi"
+							role="img"
+							viewBox="45 91 422 361"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<defs>
+								<clipPath id="kissChatLens">
+									<circle cx="195" cy="241" r="138" />
+								</clipPath>
+							</defs>
+							<path
+								d="M 123 353 L 67 440 L 169 374 Z"
+								fill="#3df08c"
+							/>
+							<circle cx="195" cy="241" r="138" fill="#3df08c" />
+							<path
+								d="M 389 353 L 445 440 L 343 374 Z"
+								fill="#2fd4b4"
+							/>
+							<circle cx="317" cy="241" r="138" fill="#2fd4b4" />
+							<circle
+								cx="317"
+								cy="241"
+								r="138"
+								fill="#d9fbea"
+								clip-path="url(#kissChatLens)"
+							/>
+							<line
+								x1="223"
+								y1="207"
+								x2="289"
+								y2="274"
+								stroke="#0d1117"
+								stroke-width="31"
+								stroke-linecap="round"
+							/>
+							<line
+								x1="289"
+								y1="207"
+								x2="223"
+								y2="274"
+								stroke="#0d1117"
+								stroke-width="31"
+								stroke-linecap="round"
+							/></svg
+					></a>
+					<a
 						href="#"
 						class="icon"
 						data-bs-toggle="modal"


### PR DESCRIPTION
## What

Adds a social-nav button on the homepage linking to the [`kiss_chat`](https://crates.io/crates/kiss_chat) crate. It sits centrally between the GitHub and Photography icons, so the order is now: Bluesky → GitHub → **kiss_chat** → Photography → ORCiD.

## Why

Surfaces the new `kiss_chat` project alongside my other links.

## Notes for reviewers

- The kiss_chat brand mark is **inlined as SVG** rather than routed through the generated `public/icons.svg` sprite. That sprite is monochrome (`fill: currentColor`) and regenerated from `bootstrap-icons` on every build, so a multi-colour logo with a `clipPath` can't live there — and external `<use>` + internal clip-path is unreliable across browsers. The clip-path id is namespaced (`kissChatLens`) to avoid collisions.
- I used the `mark.svg` variant (transparent background) from the kiss_chat logo pack, which the brand README recommends for this use. It renders legibly in both light and dark themes (the dark "x" sits on the light "lens" region).
- `.claude/launch.json` (a local dev-server preview config) is added to `.gitignore`.

## Verification

- `npx prettier --check index.html` — clean
- `npm run lint` (ESLint) and `npm run build` — pass
- Rendered locally in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)